### PR TITLE
fix: resolve severity label from both group and alert labels

### DIFF
--- a/src/karma_mcp/server.py
+++ b/src/karma_mcp/server.py
@@ -106,19 +106,40 @@ def extract_label_value(labels: list, name: str, default: str = "unknown") -> st
     return default
 
 
+def labels_list_to_dict(labels: list) -> dict:
+    """Convert a list of {name, value} label objects to a flat dict"""
+    result = {}
+    if labels:
+        for label in labels:
+            name = label.get("name", "")
+            if name:
+                result[name] = label.get("value", "")
+    return result
+
+
+def resolve_severity(group_labels_dict: dict, alert_labels_dict: dict, default: str = "none") -> str:
+    """Resolve severity by checking group labels first, then alert labels.
+
+    Severity can appear at either the group or alert level depending on
+    how Karma groups alerts. This helper ensures we always check both.
+    """
+    severity = group_labels_dict.get("severity") or alert_labels_dict.get("severity")
+    return severity if severity else default
+
+
 def extract_alert_metadata(group, alert):
     """Extract common alert metadata (alertname, severity, namespace, cluster)"""
     group_labels = group.get("labels", [])
     alert_labels = alert.get("labels", [])
 
-    alertname = extract_label_value(group_labels, "alertname", "Unknown")
+    group_labels_dict = labels_list_to_dict(group_labels)
+    alert_labels_dict = labels_list_to_dict(alert_labels)
 
-    # Severity can be in group or alert labels
-    severity = extract_label_value(group_labels, "severity")
-    if severity == "unknown":
-        severity = extract_label_value(alert_labels, "severity", "none")
+    alertname = group_labels_dict.get("alertname", extract_label_value(group_labels, "alertname", "Unknown"))
 
-    namespace = extract_label_value(alert_labels, "namespace", "N/A")
+    severity = resolve_severity(group_labels_dict, alert_labels_dict)
+
+    namespace = alert_labels_dict.get("namespace", group_labels_dict.get("namespace", "N/A"))
 
     # Extract cluster from alertmanager info
     cluster = "unknown"
@@ -545,8 +566,8 @@ async def list_active_alerts() -> str:
                                     {
                                         "name": alertname,
                                         "state": alert_state,
-                                        "severity": group_labels_dict.get(
-                                            "severity", "unknown"
+                                        "severity": resolve_severity(
+                                            group_labels_dict, alert_labels_dict
                                         ),
                                         "namespace": alert_labels_dict.get(
                                             "namespace", "N/A"
@@ -639,8 +660,8 @@ async def list_suppressed_alerts() -> str:
                                     {
                                         "name": alertname,
                                         "state": alert_state,
-                                        "severity": group_labels_dict.get(
-                                            "severity", "unknown"
+                                        "severity": resolve_severity(
+                                            group_labels_dict, alert_labels_dict
                                         ),
                                         "namespace": alert_labels_dict.get(
                                             "namespace", "N/A"
@@ -792,8 +813,8 @@ async def get_alert_details_multi_cluster(
                                             ),
                                             "cluster": cluster,
                                             "state": alert.get("state", "unknown"),
-                                            "severity": group_labels_dict.get(
-                                                "severity", "unknown"
+                                            "severity": resolve_severity(
+                                                group_labels_dict, alert_labels_dict
                                             ),
                                             "namespace": alert_labels_dict.get(
                                                 "namespace", "N/A"
@@ -1008,8 +1029,8 @@ async def search_alerts_by_container(
                                             "container": alert_container,
                                             "cluster": cluster,
                                             "state": alert.get("state", "unknown"),
-                                            "severity": group_labels_dict.get(
-                                                "severity", "unknown"
+                                            "severity": resolve_severity(
+                                                group_labels_dict, alert_labels_dict
                                             ),
                                             "namespace": alert_labels_dict.get(
                                                 "namespace", "N/A"

--- a/tests/fixtures/karma_data.py
+++ b/tests/fixtures/karma_data.py
@@ -140,6 +140,82 @@ SAMPLE_KARMA_RESPONSE = {
     "receivers": ["web.hook"],
 }
 
+# Sample response where severity is at alert level, not group level.
+# This happens when Karma groups alerts by alertname only and severity
+# differs across instances or is not part of the grouping key.
+SAMPLE_KARMA_RESPONSE_SEVERITY_ON_ALERT = {
+    "status": "success",
+    "timestamp": "2025-09-04T10:00:00Z",
+    "version": "v0.120",
+    "upstreams": {
+        "counters": {"healthy": 1, "failed": 0},
+        "instances": [
+            {
+                "name": "alertmanager",
+                "cluster": "infratest-dev",
+                "publicURI": "http://alertmanager.monitoring.svc.cluster.local",
+                "version": "0.25.0",
+                "error": "",
+            }
+        ],
+    },
+    "grids": [
+        {
+            "labelName": "",
+            "labelValue": "",
+            "alertGroups": [
+                {
+                    "receiver": "web.hook",
+                    "labels": [
+                        {"name": "alertname", "value": "KubePodCrashLooping"},
+                    ],
+                    "alerts": [
+                        {
+                            "annotations": [
+                                {
+                                    "name": "description",
+                                    "value": "Pod is crash looping",
+                                },
+                            ],
+                            "labels": [
+                                {"name": "severity", "value": "critical"},
+                                {"name": "instance", "value": "10.55.158.226:8080"},
+                                {"name": "namespace", "value": "argocd-edge"},
+                                {"name": "pod", "value": "app-pod-789"},
+                            ],
+                            "startsAt": "2025-09-04T09:30:00Z",
+                            "state": "active",
+                            "alertmanager": [
+                                {
+                                    "cluster": "infratest-dev",
+                                    "name": "alertmanager",
+                                    "state": "active",
+                                }
+                            ],
+                            "receiver": "web.hook",
+                            "id": "alert-4",
+                        },
+                    ],
+                    "id": "group-3",
+                    "alertmanagerCount": {"active": 1},
+                    "stateCount": {"active": 1},
+                    "totalAlerts": 1,
+                },
+            ],
+            "totalGroups": 1,
+            "stateCount": {"active": 1},
+        }
+    ],
+    "totalAlerts": 1,
+    "labelNames": ["alertname", "severity", "instance", "namespace"],
+    "colors": {},
+    "filters": [],
+    "silences": [],
+    "settings": {},
+    "authentication": {},
+    "receivers": ["web.hook"],
+}
+
 # Sample empty response
 EMPTY_KARMA_RESPONSE = {
     "status": "success",

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -9,17 +9,140 @@ import pytest
 
 from karma_mcp.server import (
     check_karma,
+    extract_alert_metadata,
     get_alert_details,
     get_alert_details_multi_cluster,
     get_alerts_by_state,
     get_alerts_summary,
+    labels_list_to_dict,
     list_active_alerts,
     list_alerts,
     list_alerts_by_cluster,
     list_clusters,
     list_suppressed_alerts,
+    resolve_severity,
     search_alerts_by_container,
 )
+
+
+class TestSeverityExtraction:
+    """Test suite for severity label extraction from both group and alert labels"""
+
+    def test_labels_list_to_dict(self):
+        """Test converting label list to dict"""
+        labels = [
+            {"name": "severity", "value": "critical"},
+            {"name": "namespace", "value": "default"},
+        ]
+        result = labels_list_to_dict(labels)
+        assert result == {"severity": "critical", "namespace": "default"}
+
+    def test_labels_list_to_dict_empty(self):
+        """Test converting empty label list"""
+        assert labels_list_to_dict([]) == {}
+        assert labels_list_to_dict(None) == {}
+
+    def test_resolve_severity_from_group_labels(self):
+        """Test severity found in group labels"""
+        group = {"severity": "critical"}
+        alert = {"namespace": "default"}
+        assert resolve_severity(group, alert) == "critical"
+
+    def test_resolve_severity_from_alert_labels(self):
+        """Test severity found only in alert labels (not in group)"""
+        group = {"alertname": "KubePodCrashLooping"}
+        alert = {"severity": "critical", "namespace": "default"}
+        assert resolve_severity(group, alert) == "critical"
+
+    def test_resolve_severity_missing_from_both(self):
+        """Test severity missing from both group and alert labels"""
+        group = {"alertname": "TestAlert"}
+        alert = {"namespace": "default"}
+        assert resolve_severity(group, alert) == "none"
+
+    def test_resolve_severity_group_takes_precedence(self):
+        """Test group severity takes precedence over alert severity"""
+        group = {"severity": "warning"}
+        alert = {"severity": "critical"}
+        assert resolve_severity(group, alert) == "warning"
+
+    def test_extract_alert_metadata_severity_at_group_level(self):
+        """Test metadata extraction when severity is at group level"""
+        group = {
+            "labels": [
+                {"name": "alertname", "value": "KubePodCrashLooping"},
+                {"name": "severity", "value": "critical"},
+            ],
+        }
+        alert = {
+            "labels": [
+                {"name": "namespace", "value": "production"},
+            ],
+            "state": "active",
+            "alertmanager": [{"cluster": "prod", "name": "am1"}],
+        }
+        metadata = extract_alert_metadata(group, alert)
+        assert metadata["severity"] == "critical"
+
+    def test_extract_alert_metadata_severity_at_alert_level(self):
+        """Test metadata extraction when severity is only at alert level"""
+        group = {
+            "labels": [
+                {"name": "alertname", "value": "KubePodCrashLooping"},
+            ],
+        }
+        alert = {
+            "labels": [
+                {"name": "severity", "value": "critical"},
+                {"name": "namespace", "value": "argocd-edge"},
+            ],
+            "state": "active",
+            "alertmanager": [{"cluster": "infratest-dev", "name": "am1"}],
+        }
+        metadata = extract_alert_metadata(group, alert)
+        assert metadata["severity"] == "critical"
+        assert metadata["namespace"] == "argocd-edge"
+        assert metadata["cluster"] == "infratest-dev"
+
+    @pytest.mark.asyncio
+    async def test_list_active_alerts_severity_at_alert_level(self, env_setup):
+        """Test list_active_alerts correctly shows severity from alert labels"""
+        from tests.fixtures.karma_data import SAMPLE_KARMA_RESPONSE_SEVERITY_ON_ALERT
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = SAMPLE_KARMA_RESPONSE_SEVERITY_ON_ALERT
+            mock_client.post.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await list_active_alerts()
+
+            assert "KubePodCrashLooping" in result
+            assert "critical" in result.lower()
+            # Must NOT show "unknown" or "none" for severity
+            assert "Severity: unknown" not in result
+            assert "Severity: none" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_alerts_by_cluster_severity_at_alert_level(self, env_setup):
+        """Test list_alerts_by_cluster correctly shows severity from alert labels"""
+        from tests.fixtures.karma_data import SAMPLE_KARMA_RESPONSE_SEVERITY_ON_ALERT
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = SAMPLE_KARMA_RESPONSE_SEVERITY_ON_ALERT
+            mock_client.post.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await list_alerts_by_cluster("infratest-dev")
+
+            assert "KubePodCrashLooping" in result
+            assert "critical" in result.lower()
+            assert "Severity: none" not in result
 
 
 class TestCheckKarma:


### PR DESCRIPTION
## Summary

- Severity can appear at either the group or alert level depending on how Karma groups alerts. Previously, several code paths only checked group labels, returning "unknown" or "none" when severity was only on the alert.
- Adds `resolve_severity()` and `labels_list_to_dict()` helpers and uses them consistently across all 5 code paths that extract severity.
- Adds test fixture reproducing the real-world scenario and 10 new unit tests.

Fixes https://github.com/driosalido/mcp-karma/issues/1

INFRA-599

## Test plan

- [x] All 88 unit tests pass
- [ ] Deploy new image version and verify severity shows correctly for alerts on internal-sta and infratest-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)